### PR TITLE
Minor fixes to make Dashboard compatible with OpenJDK 11

### DIFF
--- a/dashboard-server/src/main/java/dashboard/sab/SabResponseParser.java
+++ b/dashboard-server/src/main/java/dashboard/sab/SabResponseParser.java
@@ -16,7 +16,6 @@
 package dashboard.sab;
 
 import com.google.common.base.Throwables;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -197,7 +196,7 @@ public class SabResponseParser {
         }
 
         @Override
-        public Iterator<?> getPrefixes(String namespaceURI) {
+        public Iterator<String> getPrefixes(String namespaceURI) {
             return null;
         }
     }


### PR DESCRIPTION
Added support for building Dashboard with OpenJDK 11 and fixed issue #81 

Tested locally and still works with OpenJDK 8 and OpenJDK 11

@oharsta Could you verify the changes?