### PR TITLE
Streamline version numbers used for the modules

### DIFF
--- a/dashboard-gui/pom.xml
+++ b/dashboard-gui/pom.xml
@@ -3,7 +3,7 @@
    <parent>
        <groupId>org.openconext</groupId>
        <artifactId>dashboard</artifactId>
-       <version>1.0.0</version>
+       <version>10.1.6</version>
        <relativePath>../pom.xml</relativePath>
    </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/dashboard-server/pom.xml
+++ b/dashboard-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.openconext</groupId>
         <artifactId>dashboard</artifactId>
-        <version>1.0.0</version>
+        <version>10.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.openconext</groupId>
   <artifactId>dashboard</artifactId>
-  <version>1.0.0</version>
+  <version>10.1.6</version>
   <name>dashboard</name>
   <description>OpenConext-Dashboard</description>
   <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
Streamline the parent pom to release the same version as the GUI and Server, so it makes the release process more clear.