### PR TITLE
Fix SAB call to use 'guid' parameter instead of 'abbrev'.

### DIFF
--- a/dashboard-server/src/main/java/dashboard/sab/HttpClientTransport.java
+++ b/dashboard-server/src/main/java/dashboard/sab/HttpClientTransport.java
@@ -83,8 +83,8 @@ public class HttpClientTransport implements SabTransport {
     }
 
     @Override
-    public InputStream getRestResponse(String organisationAbbreviation, String role) throws IOException {
-        HttpGet httpGet = new HttpGet(format("%s/profile?abbrev=%s&role=%s", restEndPoint, URLEncoder.encode(organisationAbbreviation, "UTF-8"), URLEncoder.encode(role, "UTF-8")));
+    public InputStream getRestResponse(String organisationGuid, String role) throws IOException {
+        HttpGet httpGet = new HttpGet(format("%s/profile?guid=%s&role=%s", restEndPoint, URLEncoder.encode(organisationGuid, "UTF-8"), URLEncoder.encode(role, "UTF-8")));
         return handleRequest(httpGet, restCredentials);
     }
 

--- a/dashboard-server/src/main/java/dashboard/sab/Sab.java
+++ b/dashboard-server/src/main/java/dashboard/sab/Sab.java
@@ -35,7 +35,7 @@ public interface Sab {
     /**
      * Get all persons within the given organisation that have the given role.
      */
-    Collection<SabPerson> getPersonsInRoleForOrganization(String organisationAbbreviation, String role);
+    Collection<SabPerson> getPersonsInRoleForOrganization(String organisationGuid, String role);
 
     /**
      * Get all persons from the given organization that have the given role

--- a/dashboard-server/src/main/java/dashboard/sab/SabClient.java
+++ b/dashboard-server/src/main/java/dashboard/sab/SabClient.java
@@ -71,11 +71,11 @@ public class SabClient implements Sab {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Collection<SabPerson> getPersonsInRoleForOrganization(String organisationAbbreviation, String role) {
-        try (InputStream inputStream = sabTransport.getRestResponse(organisationAbbreviation, role)) {
+    public Collection<SabPerson> getPersonsInRoleForOrganization(String organisationGuid, String role) {
+        try (InputStream inputStream = sabTransport.getRestResponse(organisationGuid, role)) {
             String json = IOUtils.toString(inputStream, Charset.defaultCharset());
 
-            LOG.debug("SAB results 'getPersonsInRoleForOrganization' for {} {} is {}", organisationAbbreviation, role, json);
+            LOG.debug("SAB results 'getPersonsInRoleForOrganization' for {} {} is {}", organisationGuid, role, json);
 
             List<Map<String, Object>> profiles = (List<Map<String, Object>>) objectMapper.readValue(json, HashMap.class).get("profiles");
 

--- a/dashboard-server/src/main/java/dashboard/sab/SabClientMock.java
+++ b/dashboard-server/src/main/java/dashboard/sab/SabClientMock.java
@@ -52,7 +52,7 @@ public class SabClientMock implements Sab {
     }
 
     @Override
-    public Collection<SabPerson> getPersonsInRoleForOrganization(String organisationAbbreviation, String role) {
+    public Collection<SabPerson> getPersonsInRoleForOrganization(String organisationGuid, String role) {
         return sabPersons.stream()
                 .filter(person -> person.getRoles().stream().anyMatch(r -> r.roleName.equals(role)))
                 .collect(toList());

--- a/dashboard-server/src/main/java/dashboard/sab/SabTransport.java
+++ b/dashboard-server/src/main/java/dashboard/sab/SabTransport.java
@@ -22,5 +22,5 @@ public interface SabTransport {
 
     InputStream getResponse(String request) throws IOException;
 
-    InputStream getRestResponse(String organisationAbbreviation, String role) throws IOException;
+    InputStream getRestResponse(String organisationGuid, String role) throws IOException;
 }

--- a/dashboard-server/src/test/java/dashboard/sab/LocalFileTransport.java
+++ b/dashboard-server/src/test/java/dashboard/sab/LocalFileTransport.java
@@ -35,7 +35,7 @@ public class LocalFileTransport implements SabTransport {
     }
 
     @Override
-    public InputStream getRestResponse(String organisationAbbreviation, String role) {
+    public InputStream getRestResponse(String organisationGuid, String role) {
         return this.getClass().getResourceAsStream(restFileName);
     }
 }

--- a/dashboard-server/src/test/java/dashboard/sab/SabClientTest.java
+++ b/dashboard-server/src/test/java/dashboard/sab/SabClientTest.java
@@ -73,21 +73,21 @@ public class SabClientTest {
 
     @Test
     public void testGetPersonsInRoleForOrganization() throws Exception {
-        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationAbbreviation", "SURFconextverantwoordelijke");
+        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationGuid", "SURFconextverantwoordelijke");
         actual.stream().forEach(sabPerson -> assertTrue(StringUtils.hasText(sabPerson.getMiddleName())));
         assertEquals(6, actual.size());
     }
 
     @Test
     public void testOnlyReturnsPersonsWithTheGivenRole() throws Exception {
-        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationAbbreviation", "OperationeelBeheerder");
+        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationGuid", "OperationeelBeheerder");
         assertEquals(4, actual.size());
     }
 
     @Test
     public void testNoResultsFromRestInterface() throws Exception {
         sabClient = new SabClient(new LocalFileTransport("/response.xml", "/sab-json/minimal-roles.json"));
-        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationAbbreviation", "SURFconextbeheerder");
+        Collection<SabPerson> actual = sabClient.getPersonsInRoleForOrganization("organisationGuid", "SURFconextbeheerder");
         assertEquals(0, actual.size());
     }
 


### PR DESCRIPTION
The internal institutionId is now the guid. So the SAB API should be called with the 'guid=' parameter instead of 'abbrev='. Update variables for consistency.